### PR TITLE
Copy assets from project 'src/main/resources' directory

### DIFF
--- a/src/main/java/org/ois/plugin/tasks/PrepareSimulationTask.java
+++ b/src/main/java/org/ois/plugin/tasks/PrepareSimulationTask.java
@@ -105,10 +105,17 @@ public class PrepareSimulationTask extends DefaultTask {
             projectSimulationDir = SimulationUtils.getProjectSimulationConfigDirectory(project);
         }
         log.debug("Project simulation directory: {}", projectSimulationDir);
+        // Copy files from assets directory in simulation dir
         Path projectAssetsDir = projectSimulationDir.resolve(Assets.ASSETS_DIRECTORY);
         if (projectAssetsDir.toFile().exists() && projectAssetsDir.toFile().isDirectory()) {
             log.debug("'assets' directory located, copy content");
             FileUtils.copyDirectoryContent(projectAssetsDir, SimulationUtils.getSimulationRunnersAssetsDirectory(project));
+        }
+        // Copy files from resources directory in the project
+        Path projectResourceDir = SimulationUtils.getProjectResourcesDirectory(project);
+        if (projectResourceDir.toFile().exists() && projectResourceDir.toFile().isDirectory()) {
+            log.debug("'resources' directory located, copy content");
+            FileUtils.copyDirectoryContent(projectResourceDir, SimulationUtils.getSimulationRunnersAssetsDirectory(project));
         }
         // Prepare Icons
         prepareIcons(runner, projectSimulationDir);

--- a/src/main/java/org/ois/plugin/utils/SimulationUtils.java
+++ b/src/main/java/org/ois/plugin/utils/SimulationUtils.java
@@ -42,6 +42,15 @@ public class SimulationUtils {
     }
 
     /**
+     * Get the 'resources' directory path of the project
+     * @param project - the OIS project
+     * @return the path to its 'resources' directory
+     */
+    public static Path getProjectResourcesDirectory(Project project) {
+        return project.getProjectDir().toPath().resolve("src").resolve("main").resolve("resources");
+    }
+
+    /**
      * Get the 'ois' directory path for the project, the main directory generated and used by the plugin tasks.
      * @param project - the OIS project
      * @return the path to its 'ois' directory


### PR DESCRIPTION
- [ ] All [tests](https://github.com/attiasas/ois-gradle-plugin/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] If this feature effect users, update the [documentation](https://github.com/attiasas/ois-gradle-plugin/blob/main/README.md) and the [wiki](https://github.com/attiasas/ois-core/wiki)
- [ ] This feature was validated on all supported platforms
-----

Plugin will now also use the project `src/main/resources` directory as assets in the simulation.
The files in the directory will be copied to the `assets` directory for the runners